### PR TITLE
Use a format string for the version text on about dialog

### DIFF
--- a/app/src/main/java/com/llamacorp/equate/view/CalcActivity.java
+++ b/app/src/main/java/com/llamacorp/equate/view/CalcActivity.java
@@ -819,7 +819,7 @@ public class CalcActivity extends AppCompatActivity
 
 			new AlertDialog.Builder(mAppContext)
 					  .setTitle(getText(R.string.about_title))
-					  .setMessage(getText(R.string.about_version) + version +
+					  .setMessage(String.format(getText(R.string.about_version).toString(), version) +
 								 "\n\n" + getText(R.string.about_message))
 					  .setPositiveButton(android.R.string.yes, null)
 					  .show();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,7 +58,7 @@
    <string name="add_unit">Create New Unit</string>
 
    <string name="about_title">About Equate</string>
-   <string name="about_version">Version: </string>
+   <string name="about_version">Version: %s</string>
    <string name="about_message">Comments, bugs, suggestions, or if you would like to tip the dev: github.com/EvanRespaut/Equate</string>
 
    <string name="click_another_unit">Click a different unit to perform a conversion</string>


### PR DESCRIPTION
Enables more solid translations.
Fixes the ineffective space between "Version:" and the actual version string, as the space within the xml tag is ignored.
An alternative to this would be to specify the space using `Version:&nbsp;`