### PR TITLE
Fix minus button

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
    <string name="nine_button">9</string>
 
    <string name="plus_button">+</string>
-   <string name="minus_button">-</string>
+   <string name="minus_button">−</string>
    <string name="multiply_button">×</string>
    <string name="divide_button">÷</string>
 


### PR DESCRIPTION
The minus button currently using hyphen-minus character, which looks slightly shorter than +, × and ÷. To fix this issue, I replace it by Unicode minus sign (−, U+2212).

See: https://en.m.wikipedia.org/wiki/Plus_and_minus_signs